### PR TITLE
Allow staff members (staff/moderator) to remove job and portfolio posts of others users.

### DIFF
--- a/src/interactions/slash-commands/remove-post.js
+++ b/src/interactions/slash-commands/remove-post.js
@@ -1,6 +1,6 @@
 import { SlashCommand } from 'hiei.js'
 import { ApplicationCommandOptionType, PermissionFlagsBits } from 'discord.js'
-import { isStaff } from '../utilities/discord-util.js'
+import { isStaff } from '../../utilities/discord-util.js'
 import log from '../../utilities/logger.js'
 import prisma from '../../utilities/prisma-client.js'
 

--- a/src/interactions/slash-commands/remove-post.js
+++ b/src/interactions/slash-commands/remove-post.js
@@ -1,5 +1,6 @@
 import { SlashCommand } from 'hiei.js'
 import { ApplicationCommandOptionType, PermissionFlagsBits } from 'discord.js'
+import { isStaff } from '../utilities/discord-util.js'
 import log from '../../utilities/logger.js'
 import prisma from '../../utilities/prisma-client.js'
 
@@ -59,7 +60,7 @@ class RemovePost extends SlashCommand {
         const channel = await interaction.guild.channels.fetch(post.channel)
         const message = await channel.messages.fetch(post.messageId)
 
-        if (message.content.includes(interaction.member.id) && post.authorId === interaction.member.id) {
+        if (isStaff(interaction.member) || (message.content.includes(interaction.member.id) && post.authorId === interaction.member.id)) {
           await message.delete()
           await prisma.job.delete({
             where: { messageId: id }
@@ -87,7 +88,7 @@ class RemovePost extends SlashCommand {
         const channel = await interaction.guild.channels.fetch(post.channel)
         const message = await channel.messages.fetch(post.messageId)
 
-        if (message.content.includes(interaction.member.id) && post.authorId === interaction.member.id) {
+        if (isStaff(interaction.member) || (message.content.includes(interaction.member.id) && post.authorId === interaction.member.id)) {
           await message.delete()
           await prisma.portfolio.delete({
             where: { messageId: id }

--- a/src/utilities/discord-util.js
+++ b/src/utilities/discord-util.js
@@ -12,3 +12,13 @@ export function createModalCollector (client, interaction) {
     max: 1
   })
 }
+
+/** Detect whether a member is an admin or moderator
+ * @param {member} member - The guild member
+*/
+export function isStaff (member) {
+  const isAdmin = member.roles.cache.some(role => role.id === process.env.ADMIN_ROLE)
+  const isModerator = member.roles.cache.some(role => role.id === process.env.MODERATOR_ROLE)
+
+  return isAdmin || isModerator
+}


### PR DESCRIPTION
## Description

Changes aim to allow staff members to remove job/portfolio posts of other users. By default, users are only allowed to remove their own job/portfolio posts.
While staff members can actively delete the message posted by manny into the various job-board channels, doing so won't remove the job/portfolio post from the backend.
With this change, staff members should now be able to bypass the requirement to be the author of such a post.

## What was changed

Similar to quinn, manny now has an `isStaff` method (copy-pasted) in `discord-util.js` to allow testing if a given member is a staff member or not.
Inside `remove-post.js`, the `isStaff` method is now used to bypass the requirement for the user invoking the slash command to be the author of the post that they want to remove.

## What hasn't been done

I have not actively tested this. I don't have the time at the moment to set up all of the required dev environment.
I also don't know if this requires changes to the .env file to define `ADMIN_ROLE` and `MODERATOR_ROLE`.